### PR TITLE
ci: added a workflow

### DIFF
--- a/.github/workflows/sync-snap.yml
+++ b/.github/workflows/sync-snap.yml
@@ -1,0 +1,32 @@
+name: Update
+
+on:
+  # Runs at 10:00 UTC every day
+  schedule:
+    - cron:  '0 10 * * *'
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sync:
+    name: 🔄 Sync version with upstream
+    environment: "Main Branch"
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🔄 Sync version with upstream
+        uses: snapcrafters/ci/sync-version@main
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: "main"
+          update-script: |
+            VIVALDI_VERSION=$(curl -s https://vivaldi.com/download/ | grep -oP 'href="https://downloads.vivaldi.com/stable/vivaldi-stable_\K[0-9.]+(?=-1_amd64\.deb)')
+            sed -i 's/^\(version: \).*$/\1'"$VIVALDI_VERSION"'/' snapcraft.yaml
+
+            # Grab the latest version of the chromium-ffmpeg snap 
+            # which is in the candidate channel, for arm64
+            CHROMIUM_FFMPEG_VERSION=$(curl -s -X GET   -H "Snap-Device-Series: 16"   -H "User-Agent: custom-client/1.0"   "https://api.snapcraft.io/v2/snaps/info/chromium-ffmpeg?fields=version" | jq -r '.["channel-map"][] | select(.channel.name == "candidate" and .channel.architecture == "arm64")' | jq -r ".version" | cut --delimiter "-" -f 1)
+            sed -i "s/chromium-ffmpeg-[0-9]\{6\}/chromium-ffmpeg-$CHROMIUM_FFMPEG_VERSION/" snapcraft.yaml

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: vivaldi
-version: 7.5.3735.66
+version: 7.5.3735.74
 summary: Vivaldi Browser - Feature-packed web browser
 description: |
     The web browser for techies and people who need a browser that helps them get things done.

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: vivaldi
-version: 7.3.3635.12
+version: 7.3.3635.14
 summary: Vivaldi Browser - Feature-packed web browser
 description: |
     The web browser for techies and people who need a browser that helps them get things done.

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: vivaldi
-version: 7.1.3570.50
+version: 7.1.3570.54
 summary: Vivaldi Browser - Feature-packed web browser
 description: |
     The web browser for techies and people who need a browser that helps them get things done.

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: vivaldi
-version: 7.1.3570.54
+version: 7.1.3570.58
 summary: Vivaldi Browser - Feature-packed web browser
 description: |
     The web browser for techies and people who need a browser that helps them get things done.

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: vivaldi
-version: 7.3.3635.4
+version: 7.3.3635.7
 summary: Vivaldi Browser - Feature-packed web browser
 description: |
     The web browser for techies and people who need a browser that helps them get things done.

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: vivaldi
-version: 7.4.3684.38
+version: 7.4.3684.43
 summary: Vivaldi Browser - Feature-packed web browser
 description: |
     The web browser for techies and people who need a browser that helps them get things done.

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: vivaldi
-version: 7.1.3570.39
+version: 7.1.3570.42
 summary: Vivaldi Browser - Feature-packed web browser
 description: |
     The web browser for techies and people who need a browser that helps them get things done.
@@ -67,7 +67,7 @@ plugs:
   shmem:
     interface: shared-memory
     private: true
-  chromium-ffmpeg-118887:
+  chromium-ffmpeg-119293:
     interface: content
     target: $SNAP
     default-provider: chromium-ffmpeg

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: vivaldi
-version: 7.3.3635.14
+version: 7.4.3684.38
 summary: Vivaldi Browser - Feature-packed web browser
 description: |
     The web browser for techies and people who need a browser that helps them get things done.

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: vivaldi
-version: 7.3.3635.9
+version: 7.3.3635.11
 summary: Vivaldi Browser - Feature-packed web browser
 description: |
     The web browser for techies and people who need a browser that helps them get things done.

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: vivaldi
-version: 7.0.3495.27
+version: 7.0.3495.29
 summary: Vivaldi Browser - Feature-packed web browser
 description: |
     The web browser for techies and people who need a browser that helps them get things done.

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -67,7 +67,7 @@ plugs:
   shmem:
     interface: shared-memory
     private: true
-  chromium-ffmpeg-119293:
+  chromium-ffmpeg-119605:
     interface: content
     target: $SNAP
     default-provider: chromium-ffmpeg

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: vivaldi
-version: 7.4.3684.55
+version: 7.5.3735.41
 summary: Vivaldi Browser - Feature-packed web browser
 description: |
     The web browser for techies and people who need a browser that helps them get things done.

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -67,7 +67,7 @@ plugs:
   shmem:
     interface: shared-memory
     private: true
-  chromium-ffmpeg-119605:
+  chromium-ffmpeg-120726:
     interface: content
     target: $SNAP
     default-provider: chromium-ffmpeg

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: vivaldi
-version: 7.5.3735.41
+version: 7.5.3735.44
 summary: Vivaldi Browser - Feature-packed web browser
 description: |
     The web browser for techies and people who need a browser that helps them get things done.

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: vivaldi
-version: 7.5.3735.56
+version: 7.5.3735.58
 summary: Vivaldi Browser - Feature-packed web browser
 description: |
     The web browser for techies and people who need a browser that helps them get things done.

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: vivaldi
-version: 7.4.3684.46
+version: 7.4.3684.50
 summary: Vivaldi Browser - Feature-packed web browser
 description: |
     The web browser for techies and people who need a browser that helps them get things done.

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: vivaldi
-version: 7.3.3635.2
+version: 7.3.3635.4
 summary: Vivaldi Browser - Feature-packed web browser
 description: |
     The web browser for techies and people who need a browser that helps them get things done.

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: vivaldi
-version: 7.2.3621.67
+version: 7.3.3635.2
 summary: Vivaldi Browser - Feature-packed web browser
 description: |
     The web browser for techies and people who need a browser that helps them get things done.

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: vivaldi
-version: 7.6.3797.55
+version: 7.6.3797.56
 summary: Vivaldi Browser - Feature-packed web browser
 description: |
     The web browser for techies and people who need a browser that helps them get things done.

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: vivaldi
-version: 7.1.3570.60
+version: 7.2.3621.63
 summary: Vivaldi Browser - Feature-packed web browser
 description: |
     The web browser for techies and people who need a browser that helps them get things done.

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: vivaldi
-version: 7.1.3570.42
+version: 7.1.3570.47
 summary: Vivaldi Browser - Feature-packed web browser
 description: |
     The web browser for techies and people who need a browser that helps them get things done.

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: vivaldi
-version: 7.4.3684.50
+version: 7.4.3684.52
 summary: Vivaldi Browser - Feature-packed web browser
 description: |
     The web browser for techies and people who need a browser that helps them get things done.

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: vivaldi
-version: 7.6.3797.52
+version: 7.6.3797.55
 summary: Vivaldi Browser - Feature-packed web browser
 description: |
     The web browser for techies and people who need a browser that helps them get things done.

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: vivaldi
-version: 7.3.3635.11
+version: 7.3.3635.12
 summary: Vivaldi Browser - Feature-packed web browser
 description: |
     The web browser for techies and people who need a browser that helps them get things done.

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: vivaldi
-version: 7.6.3797.56
+version: 7.6.3797.58
 summary: Vivaldi Browser - Feature-packed web browser
 description: |
     The web browser for techies and people who need a browser that helps them get things done.

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: vivaldi
-version: 7.3.3635.7
+version: 7.3.3635.9
 summary: Vivaldi Browser - Feature-packed web browser
 description: |
     The web browser for techies and people who need a browser that helps them get things done.

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: vivaldi
-version: 7.0.3495.29
+version: 7.1.3570.39
 summary: Vivaldi Browser - Feature-packed web browser
 description: |
     The web browser for techies and people who need a browser that helps them get things done.

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: vivaldi
-version: 7.5.3735.44
+version: 7.5.3735.47
 summary: Vivaldi Browser - Feature-packed web browser
 description: |
     The web browser for techies and people who need a browser that helps them get things done.

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: vivaldi
-version: 7.4.3684.52
+version: 7.4.3684.55
 summary: Vivaldi Browser - Feature-packed web browser
 description: |
     The web browser for techies and people who need a browser that helps them get things done.

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: vivaldi
-version: 7.1.3570.47
+version: 7.1.3570.50
 summary: Vivaldi Browser - Feature-packed web browser
 description: |
     The web browser for techies and people who need a browser that helps them get things done.

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: vivaldi
-version: 7.1.3570.58
+version: 7.1.3570.60
 summary: Vivaldi Browser - Feature-packed web browser
 description: |
     The web browser for techies and people who need a browser that helps them get things done.

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: vivaldi
-version: 7.2.3621.63
+version: 7.2.3621.67
 summary: Vivaldi Browser - Feature-packed web browser
 description: |
     The web browser for techies and people who need a browser that helps them get things done.

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: vivaldi
-version: 7.5.3735.62
+version: 7.5.3735.64
 summary: Vivaldi Browser - Feature-packed web browser
 description: |
     The web browser for techies and people who need a browser that helps them get things done.

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: vivaldi
-version: 7.5.3735.54
+version: 7.5.3735.56
 summary: Vivaldi Browser - Feature-packed web browser
 description: |
     The web browser for techies and people who need a browser that helps them get things done.

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: vivaldi
-version: 7.5.3735.47
+version: 7.5.3735.54
 summary: Vivaldi Browser - Feature-packed web browser
 description: |
     The web browser for techies and people who need a browser that helps them get things done.

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: vivaldi
-version: 7.5.3735.64
+version: 7.5.3735.66
 summary: Vivaldi Browser - Feature-packed web browser
 description: |
     The web browser for techies and people who need a browser that helps them get things done.

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: vivaldi
-version: 7.5.3735.58
+version: 7.5.3735.62
 summary: Vivaldi Browser - Feature-packed web browser
 description: |
     The web browser for techies and people who need a browser that helps them get things done.

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: vivaldi
-version: 7.5.3735.74
+version: 7.6.3797.52
 summary: Vivaldi Browser - Feature-packed web browser
 description: |
     The web browser for techies and people who need a browser that helps them get things done.

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: vivaldi
-version: 7.4.3684.43
+version: 7.4.3684.46
 summary: Vivaldi Browser - Feature-packed web browser
 description: |
     The web browser for techies and people who need a browser that helps them get things done.


### PR DESCRIPTION
- auto updates the deb version that'll be used as source
- auto updates the chromium-ffmpeg slot version

This is a CI automation workflow, that'll update the version of the snap. This will also auto update the chromium-ffmpeg version which is currently in the candidate channel and available for arm64. There are different slots in the chromium-ffmpeg snap, this chooses the first one as already done in this snap. We also have other CIs to help build and test PRs, test the snap inside the runner, build it and promote it to stable channel, all directly from Github. You can find them here.

https://github.com/snapcrafters/ci