### PR TITLE
Revert "That plug is actually not needed, implicit"

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -80,6 +80,10 @@ plugs:
     interface: personal-files
     write:
       - $HOME/.local/share/icons
+  gpu-2404:
+    interface: content
+    target: $SNAP/gpu-2404
+    default-provider: mesa-2404
 
 slots:
   mpris:


### PR DESCRIPTION
This reverts commit fa1a1812775594e0552ffc02bd5907e93af052d4.
Should fix Content snap command-chain for /snap/vivaldi/325/gpu-2404/bin/gpu-2404-provider-wrapper not found: ensure slot is connected