### PR TITLE
Filip/core24

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,16 +9,14 @@ license: Proprietary
 type: app
 website: https://vivaldi.com
 grade: stable
-base: core22
+base: core24
 icon: vivaldi_icon.png
 compression: lzo
 adopt-info: vivaldi
 
-architectures:
-- build-on: amd64
-  build-for: amd64
-- build-on: amd64
-  build-for: arm64
+platforms:
+  amd64:
+  arm64:
 
 apps:
   vivaldi-stable:
@@ -82,10 +80,6 @@ plugs:
     interface: personal-files
     write:
       - $HOME/.local/share/icons
-  gpu-2404:
-    interface: content
-    target: $SNAP/gpu-2404
-    default-provider: mesa-2404
 
 slots:
   mpris:
@@ -105,7 +99,7 @@ parts:
       - libatspi2.0-0
       - libcairo2
       - libcups2
-      - libcurl3-gnutls
+      - libcurl4
       - libdbus-1-3
       - libdrm2
       - libexpat1
@@ -125,7 +119,6 @@ parts:
       - libxkbcommon0
       - libxrandr2
       - wget
-      - libasound2
       - libgl1
     override-build: |
       snapcraftctl build
@@ -140,7 +133,9 @@ parts:
     stage-packages: [xdg-utils]
     stage: [usr/bin/xdg-icon-resource]
     override-prime: |
-      find / -path '*/usr/bin/xdg-icon-resource' -print -exec sed -i '/^xdg_user_dir="$XDG_DATA_HOME"$/s|".*"|$SNAP_REAL_HOME/.local/share/|' {} +
+      set -eu
+      sed -i '/^xdg_user_dir="$XDG_DATA_HOME"$/s|".*"|$SNAP_REAL_HOME/.local/share/|' \
+        "$CRAFT_STAGE/usr/bin/xdg-icon-resource"
       craftctl default
 
   launcher:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -80,6 +80,10 @@ plugs:
     interface: personal-files
     write:
       - $HOME/.local/share/icons
+  gpu-2404:
+    interface: content
+    target: $SNAP/gpu-2404
+    default-provider: mesa-2404
 
 slots:
   mpris:


### PR DESCRIPTION
Once again trying to transition to core24

the automatic plug issues were solved upstream, so what was left was libOSSlib.so missing - revealed itself to be a case of trying too hard - gnome plug already supplies us with libasound2 so no need to pull that in (that dep in the package was the reason for the missing libOSSlib.so).

So... let's try again - should also solve our issues with HW accel - yay