### PR TITLE
This should fix the qt not running us bug, but I don't like it

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -120,9 +120,25 @@ parts:
       - libxrandr2
       - wget
       - libgl1
+      - qtwayland5
     override-build: |
       snapcraftctl build
       chmod 755 $CRAFT_PART_INSTALL/opt/vivaldi/vivaldi-sandbox
+    # we need to link qt5 platforms plugins as otherwise QT wont run
+    # (qt searches plugin with paths relative to executable)
+    override-prime: |
+      set -eu
+      craftctl default
+      # Find the actual Qt5 Wayland platform plugin(s) that qtwayland5 should have staged
+      so_path="$(find "$CRAFT_PRIME" -type f -name 'libqwayland*.so' | head -n 1 || true)"
+      if [ -z "$so_path" ]; then
+        echo "ERROR: no libqwayland*.so found in prime; qtwayland5 not present or not staged into this part" >&2
+        exit 1
+      fi
+      src_dir="$(dirname "$so_path")"
+      dst_dir="$CRAFT_PRIME/opt/vivaldi/platforms"
+      mkdir -p "$CRAFT_PRIME/opt/vivaldi"
+      ln -s "$(realpath --relative-to="$CRAFT_PRIME/opt/vivaldi" "$src_dir")" "$dst_dir"
     parse-info: [usr/share/appdata/vivaldi.appdata.xml]
 
   # Copied from Chromium's snapcraft.yaml - patches xdg-icon-resource


### PR DESCRIPTION
Fixes the QT not loading issues (stemming from gpu-2404 not loading correctly it seems) by symlinking the libs to a place where qt expects them. Seems to be related to RUNPATH or app directory containing qt shims.